### PR TITLE
Allow 'bare' usernames instead of URLs

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,8 @@ Usage
                  https://DOMAIN/@USER
                  https://DOMAIN/@USER/with_replies
                  https://DOMAIN/@USER/media
+                 @USER@DOMAIN
+                 USER@DOMAIN
 
    options:
      -h, --help  show this help message and exit

--- a/zygolophodon
+++ b/zygolophodon
@@ -334,6 +334,15 @@ def xmain():
     opts = ap.parse_args()
     if opts.debug_http:
         UserAgent.debug_level = 1
+
+    # 'bare' usernames should be `@user@instance` or `user@instance`
+    if opts.url[0] == "@" or opts.url[0:4] != "http":
+        parts = opts.url.split("@", 3)
+        # Reverse this because `a@b = (a,b)` and `@a@b = (,a,b)`
+        # and we only want the last 2 items in either case.
+        parts.reverse()
+        opts.url = f"https://{parts[0]}/@{parts[1]}"
+
     url, _ = urllib.parse.urldefrag(opts.url)
     match = url_parser.parse(url)
     if match is None:

--- a/zygolophodon
+++ b/zygolophodon
@@ -321,6 +321,11 @@ def xmain():
         '@USER/with_replies',
         '@USER/media',
     )
+    # Support bare usernames - assume `https` as with above templates.
+    bare_usernames = [
+        '@USER@DOMAIN',
+        'USER@DOMAIN',
+    ]
     ap = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     if sys.version_info < (3, 10):
         # https://bugs.python.org/issue9694
@@ -330,7 +335,7 @@ def xmain():
         help=f'request at most N posts (default: {default_limit})'
     )
     ap.add_argument('--debug-http', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('url', metavar='URL', help=str.join('\n', url_parser.templates))
+    ap.add_argument('url', metavar='URL', help=str.join('\n', url_parser.templates + bare_usernames))
     opts = ap.parse_args()
     if opts.debug_http:
         UserAgent.debug_level = 1
@@ -341,6 +346,7 @@ def xmain():
         # Reverse this because `a@b = (a,b)` and `@a@b = (,a,b)`
         # and we only want the last 2 items in either case.
         parts.reverse()
+        # Safe to assume `https` here because the existing code already does.
         opts.url = f"https://{parts[0]}/@{parts[1]}"
 
     url, _ = urllib.parse.urldefrag(opts.url)


### PR DESCRIPTION
Allow `username@instance` or `@username@instance` instead of a URL.

Internally just converts it to the URL form before parsing, etc.