### PR TITLE
Add support for Iceshrimp notes URLs

### DIFF
--- a/README
+++ b/README
@@ -8,6 +8,7 @@ Usage
 
    positional arguments:
      ADDRESS     https://DOMAIN/statuses/NNNNNN
+                 https://DOMAIN/notes/XXXXXXXXXXXXXXXX
                  https://DOMAIN/users/USER/statuses/NNNNNN
                  https://DOMAIN/@USER/NNNNNN
                  https://DOMAIN/@USER/NNNNNN/embed

--- a/zygolophodon
+++ b/zygolophodon
@@ -311,6 +311,7 @@ class AddrParser():
             domain='[^/]+',
             user='[^/]+',
             ident='[0-9]+',
+            note='[a-z0-9]{16}',
         )
         def repl(match):
             s = match.group()
@@ -320,6 +321,8 @@ class AddrParser():
                 group = s.lower()
                 if group == 'nnnnnn':
                     group = 'ident'
+                elif group == 'xxxxxxxxxxxxxxxx':
+                    group = 'note'
                 regexp = group2regexp[group]
             else:
                 group = s
@@ -352,6 +355,7 @@ pint.__name__ = 'positive int'
 def xmain():
     addr_parser = AddrParser(
         '/statuses/NNNNNN',
+        '/notes/XXXXXXXXXXXXXXXX',
         '/users/USER/statuses/NNNNNN',
         '/@USER/NNNNNN',
         '/@USER/NNNNNN/embed',
@@ -384,14 +388,14 @@ def xmain():
         ap.error('unsupported address')
     sys.stdout.flush()
     with StdOut.install():
-        if match.ident is None:
+        if match.ident is None and match.note is None:
             process_user(match.domain, match.user,
                 replies=bool(match.with_replies),
                 media=bool(match.media),
                 limit=opts.limit,
             )
         else:
-            process_status(match.domain, match.ident,
+            process_status(match.domain, match.ident or match.note,
                 context=(opts.limit > 1 and not match.embed),
             )
 


### PR DESCRIPTION
[Iceshrimp](https://iceshrimp.dev/) is an alternative Fediverse implementation that is mostly compatible with Mastodon APIs, except that notes URLs are different to Mastodon ones.

Example notes URL: https://social.elizabeth.cat/notes/a2m7w4bjk1e3newm