### PR TITLE
Add support for Mastodon off-site redirect pages

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,7 @@ Usage
                        https://DOMAIN/@USER/NNNNNN/embed
                        https://DOMAIN/tags/TAG
                        https://DOMAIN/statuses/NNNNNN
+                       https://DOMAIN/redirect/statuses/NNNNNN
                        https://DOMAIN/users/USER
                        https://DOMAIN/users/USER/statuses/NNNNNN
                        https://DOMAIN/notes/IDENT (Iceshrimp)

--- a/zygolophodon
+++ b/zygolophodon
@@ -729,6 +729,8 @@ class Mastodon(Instance):
         '/tags/TAG',
         # legacy user-less post
         '/statuses/NNNNNN',
+        # offsite redirect pages
+        '/redirect/statuses/NNNNNN',
         # URI->URL redirects
         '/users/USER',
         '/users/USER/statuses/NNNNNN',


### PR DESCRIPTION
Mastodon links to off-site posts first HTTP redirect to a URL
that only links to the real off-site URL, for "safety".

For example [1] redirects to [2] which manual-redirects to [3].
Of these [1] is supported and neither of [2] or [3] are supported yet.
In a browser, clicking on [1] will leave you with not yet supported [2],
so it is useful to have support for [2] since the redirect there is manual
and [3] isn't supported yet.

1. https://kolektiva.social/@cacu@pixelfed.de/114240859464421461
2. https://kolektiva.social/redirect/statuses/114240859464421461
3. https://pixelfed.de/p/cacu/811263815440830587
